### PR TITLE
Fix lifting `Data.Kind.Type`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for lift-typeable
 
+## 0.1.1.1
+
+- Fix lifting the `Data.Kind.Type` into a `TemplateHaskell.Type` [#]()
+
 ## 0.1.1.0
 
 - Cleanup and a slight performance improvement [#7](https://github.com/parsonsmatt/lift-type/pull/7)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 0.1.1.1
 
-- Fix lifting the `Data.Kind.Type` into a `TemplateHaskell.Type` [#]()
+- Fix lifting the `Data.Kind.Type` into a `TemplateHaskell.Type` [#9](https://github.com/parsonsmatt/lift-type/pull/9)
 
 ## 0.1.1.0
 

--- a/lift-type.cabal
+++ b/lift-type.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 name:           lift-type
-version:        0.1.1.0
+version:        0.1.1.1
 description:    Lift your types from a Typeable constraint to a Template Haskell type
 synopsis:       Lift a type from a Typeable constraint to a Template Haskell type
 homepage:       https://github.com/parsonsmatt/lift-type#readme

--- a/src/LiftType.hs
+++ b/src/LiftType.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- | Template Haskell has a class 'Lift' that allows you to promote values
 -- from Haskell-land into the land of metaprogramming - 'Q'.
@@ -26,11 +26,11 @@
 module LiftType where
 
 import Data.Foldable (asum)
+import qualified Data.Kind as Kind
 import Data.Maybe (fromMaybe)
 import Language.Haskell.TH.Syntax
 import Text.Read (readMaybe)
 import Type.Reflection
-import qualified Data.Kind as Kind
 
 -- | 'liftType' promoted to the 'Q' monad.
 --

--- a/src/LiftType.hs
+++ b/src/LiftType.hs
@@ -47,7 +47,6 @@ typeRepToType (SomeTypeRep a) = go a
     go :: forall k (a :: k). TypeRep a -> Type
     go tr
         | Just HRefl <- eqTypeRep (typeRep @Kind.Type) tr
-        , False
         = ConT ''Kind.Type
         | otherwise =
         case tr of

--- a/src/LiftType.hs
+++ b/src/LiftType.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -23,13 +25,12 @@
 -- @since 0.1.0.0
 module LiftType where
 
-import Control.Applicative
-import Data.Char
 import Data.Foldable (asum)
 import Data.Maybe (fromMaybe)
 import Language.Haskell.TH.Syntax
 import Text.Read (readMaybe)
 import Type.Reflection
+import qualified Data.Kind as Kind
 
 -- | 'liftType' promoted to the 'Q' monad.
 --
@@ -44,7 +45,11 @@ typeRepToType :: SomeTypeRep -> Type
 typeRepToType (SomeTypeRep a) = go a
   where
     go :: forall k (a :: k). TypeRep a -> Type
-    go tr =
+    go tr
+        | Just HRefl <- eqTypeRep (typeRep @Kind.Type) tr
+        , False
+        = ConT ''Kind.Type
+        | otherwise =
         case tr of
             Con tyCon ->
                 mk tyCon

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,6 +11,7 @@ main :: IO ()
 main = do
     let
         type_ = Proxy :: Proxy $(liftTypeQ @Type)
+        type_' = Proxy :: Proxy $(liftTypeQ @TYPE)
         word# = Proxy :: Proxy $(liftTypeQ @Word#)
         bool = Proxy :: Proxy $(liftTypeQ @Bool)
         true = Proxy :: Proxy $(liftTypeQ @'True)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,12 +1,17 @@
-{-# language TemplateHaskell, DataKinds, TypeApplications #-}
+{-# language MagicHash, TemplateHaskell, DataKinds, TypeApplications #-}
+
 module Main where
 
 import LiftType
 import Data.Proxy
+import Data.Kind
+import GHC.Exts
 
 main :: IO ()
 main = do
     let
+        type_ = Proxy :: Proxy $(liftTypeQ @Type)
+        word# = Proxy :: Proxy $(liftTypeQ @Word#)
         bool = Proxy :: Proxy $(liftTypeQ @Bool)
         true = Proxy :: Proxy $(liftTypeQ @'True)
         three = Proxy :: Proxy $(liftTypeQ @3)


### PR DESCRIPTION
This PR fixes a bug where doing `liftTypeQ @Data.Kind.Type` would cause a GHC bug.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
